### PR TITLE
feat: update benchmarks publishing branch and related documentation

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           tool: benchmarkdotnet
           output-file-path: /tmp/bdn-merged.json
-          gh-pages-branch: main
+          gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmarks/results
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,6 @@ RegisterTask → StartTask → [running in TasksDataModel]
 | `ci.yml` | Push / PR | Run full xUnit test suite across all TFMs |
 | `benchmarks.yml` | Push to `main` / manual | Run BenchmarkDotNet on net8.0, net9.0, net10.0 and publish charts to GitHub Pages |
 
-Benchmark results are committed to `benchmarks/results/` on `main` and served via GitHub Pages at `https://ryujose.github.io/NetTaskManagement/benchmarks/results/`.
+Benchmark results are committed to `benchmarks/results/` on the `gh-pages` branch (managed automatically by the action) and served via GitHub Pages at `https://ryujose.github.io/NetTaskManagement/benchmarks/results`.
 
 **To release a new version:** bump the version in both `.csproj` files, commit, then push a tag: `git tag v1.2.3 && git push origin v1.2.3`

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ if (_tasks.DequeueTaskDisposedDataModel(out var record) == TaskManagementStatus.
 
 Performance is tracked automatically on every push to `main` and published as interactive charts:
 
-**[View benchmark charts](https://ryujose.github.io/NetTaskManagement/benchmarks/results/)**
+**[View benchmark charts](https://ryujose.github.io/NetTaskManagement/benchmarks/results)**
 
 Benchmarks cover:
 - `LifecycleBenchmarks` — individual lifecycle stages: Register, Start, Cancel, Delete, and full end-to-end


### PR DESCRIPTION
- Changed `gh-pages-branch` from `main` to `gh-pages` in `benchmarks.yml`.
- Updated `CLAUDE.md` to reflect the new branch for benchmark results publishing.
- Refined benchmark chart URL in `README.md` for consistency.