### PR TITLE
feat: enhance task deletion API and CI configuration, add dependabot and update documentation

### DIFF
--- a/.claude/rules
+++ b/.claude/rules
@@ -37,8 +37,8 @@ services.AddSingleton<ILogger>(sp =>
     sp.GetRequiredService<ILoggerFactory>().CreateLogger("NetFramework.Tasks.Management"));
 ```
 
-## DeleteTask — Parameter Name Mismatch
-The `ITaskManagement` interface declares the second parameter as `sendDisposedDataToInternalQueue`, but the `TasksManagement` implementation uses `sendDataToInternalQueue`. Always use the implementation's name when calling via the concrete type (e.g. in benchmarks). When calling through the interface, use the interface name.
+## DeleteTask — Parameter Name
+The second parameter of `DeleteTask` is `sendDisposedDataToInternalQueue` in both the interface and the implementation. Always use this name when calling with a named argument.
 
 ## Benchmarks
 BenchmarkDotNet benchmarks live in `benchmarks/NetFramework.Tasks.Management.Benchmarks/` and target `net8.0;net9.0;net10.0`. Rules:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+
+  - package-ecosystem: nuget
+    directory: /src
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+
+  - package-ecosystem: nuget
+    directory: /benchmarks/NetFramework.Tasks.Management.Benchmarks
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+
+  - package-ecosystem: nuget
+    directory: /examples/FinancialOrderProcessing
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,18 @@ jobs:
         run: dotnet build src/NetFramework.Task.Management.sln --configuration Release --no-restore
 
       - name: Test on .NET ${{ matrix.dotnet-version }}
-        run: dotnet test src/NetFramework.Tasks.Management.xUnit.Tests/ --configuration Release --no-build --framework net${{ matrix.dotnet-version }} --logger "console;verbosity=normal"
+        run: |
+          dotnet test src/NetFramework.Tasks.Management.xUnit.Tests/ \
+            --configuration Release \
+            --no-build \
+            --framework net${{ matrix.dotnet-version }} \
+            --logger "console;verbosity=normal" \
+            --collect:"XPlat Code Coverage" \
+            --results-directory ./coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          directory: ./coverage
+          flags: net${{ matrix.dotnet-version }}
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage
           flags: net${{ matrix.dotnet-version }}
           fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # NetTaskManagement
 
+[![CI](https://github.com/Ryujose/NetTaskManagement/actions/workflows/ci.yml/badge.svg)](https://github.com/Ryujose/NetTaskManagement/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Ryujose/NetTaskManagement/branch/main/graph/badge.svg)](https://codecov.io/gh/Ryujose/NetTaskManagement)
+
 A .NET Standard 2.0 library for Task Parallel Library (TPL) orchestration with Dependency Injection support.
 
 Tasks are identified by **string key** and managed through a **status-based API** — no raw `Task` objects exposed to callers. The library handles the full task lifecycle: register → start → cancel → check completion → delete, and exposes an append-only observability queue that captures disposal metadata for external monitoring.

--- a/benchmarks/NetFramework.Tasks.Management.Benchmarks/LifecycleBenchmarks.cs
+++ b/benchmarks/NetFramework.Tasks.Management.Benchmarks/LifecycleBenchmarks.cs
@@ -117,7 +117,7 @@ namespace NetFramework.Tasks.Management.Benchmarks
 
         [Benchmark]
         public TaskManagementStatus DeleteTask()
-            => _tasks.DeleteTask(_taskName, sendDataToInternalQueue: false);
+            => _tasks.DeleteTask(_taskName, sendDisposedDataToInternalQueue: false);
 
         [IterationCleanup(Targets = new[] { nameof(DeleteTask) })]
         public void CleanupDelete()
@@ -141,7 +141,7 @@ namespace NetFramework.Tasks.Management.Benchmarks
             _tasks.StartTask(_taskName);
             _tasks.CancelTask(_taskName);
             _tasks.CheckTaskStatusCompleted(_taskName, retry: 5, millisecondsCancellationWait: 500);
-            return _tasks.DeleteTask(_taskName, sendDataToInternalQueue: false);
+            return _tasks.DeleteTask(_taskName, sendDisposedDataToInternalQueue: false);
         }
 
         [IterationCleanup(Targets = new[] { nameof(FullLifecycle) })]

--- a/src/NetFramework.Task.Management/TasksManagement.cs
+++ b/src/NetFramework.Task.Management/TasksManagement.cs
@@ -289,7 +289,7 @@ namespace NetFramework.Tasks.Management
             return TaskManagementStatus.Completed;
         }
 
-        public TaskManagementStatus DeleteTask(string taskName, bool sendDataToInternalQueue = false)
+        public TaskManagementStatus DeleteTask(string taskName, bool sendDisposedDataToInternalQueue = false)
         {
             if (string.IsNullOrEmpty(taskName))
             {
@@ -330,7 +330,7 @@ namespace NetFramework.Tasks.Management
                 IsDisposed = true
             };
 
-            if (sendDataToInternalQueue)
+            if (sendDisposedDataToInternalQueue)
                 TaskDisposedDataModel.Enqueue(taskDisposedDataModel);
 
             _logger.LogInformation($"{nameof(taskName)}-{nameof(taskName)} {nameof(TaskManagementStatus.Deleted)} successfully");

--- a/src/NetFramework.Tasks.Management.xUnit.Tests/TaskManagementDeleteTaskTest.cs
+++ b/src/NetFramework.Tasks.Management.xUnit.Tests/TaskManagementDeleteTaskTest.cs
@@ -111,7 +111,7 @@ namespace NetFramework.Tasks.Management.Tests
             taskManagementStatus = _taskManagement.StartTask(simpleTaskName);
             taskManagementStatus = _taskManagement.CancelTask(simpleTaskName);
             taskManagementStatus = _taskManagement.CheckTaskStatusCompleted(simpleTaskName, retry: 1, millisecondsCancellationWait: 1000);
-            taskManagementStatus = _taskManagement.DeleteTask(simpleTaskName, sendDataToInternalQueue: true);
+            taskManagementStatus = _taskManagement.DeleteTask(simpleTaskName, sendDisposedDataToInternalQueue: true);
             taskManagementStatus = _taskManagement.DequeueTaskDisposedDataModel(out TaskDisposedDataModel taskDisposedDataModel);
 
             Assert.Equal(TaskManagementStatus.ObjectInfoDequeued, taskManagementStatus);


### PR DESCRIPTION
- Renamed `sendDataToInternalQueue` to `sendDisposedDataToInternalQueue` in `DeleteTask()` for clarity and consistency.
- Updated `LifecycleBenchmarks` to align with the renamed parameter.
- Integrated code coverage collection and upload to Codecov in CI workflow (`ci.yml`).
- Added Codecov and CI status badges to `README.md`.
- Introduced `dependabot.yml` for automated dependency updates.
- Improved documentation with updated links and workflow details.